### PR TITLE
Fix STOMP Connection Authentication

### DIFF
--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -105,7 +105,7 @@ class Pigeon:
         while retries < retry_limit:
             try:
                 self._connection.connect(
-                    username=username, password=password, wait=True
+                    username=username, passcode=password, wait=True
                 )
                 self._logger.info("Connected to STOMP server.")
                 break

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,7 +41,7 @@ def test_connect(pigeon_client, username, password, expected_log):
 
     # Assert
     pigeon_client._connection.connect.assert_called_with(
-        username=username, password=password, wait=True
+        username=username, passcode=password, wait=True
     )
     pigeon_client._logger.info.assert_called_with(expected_log)
 


### PR DESCRIPTION
The `pigeon.client.connect()` method incorrectly used a `password`, not `passcode`, keyword argument when connecting to the STOMP message broker.

Fixes #2