### PR TITLE
Implemented a message definition hashing system

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Pigeon is a combination of a `STOMP client <https://pypi.org/project/stomp-py/>`
 .. autoclass:: pigeon.BaseMessage
 
 .. autoexception:: pigeon.exceptions.NoSuchTopicException
-.. autoexception:: pigeon.exceptions.VersionMismatchException
+.. autoexception:: pigeon.exceptions.SignatureException
 
 Indices and tables
 ==================

--- a/examples/publisher.py
+++ b/examples/publisher.py
@@ -2,7 +2,7 @@ import os
 import time
 
 from pigeon.client import Pigeon
-from pigeon.logging import setup_logging
+from pigeon.utils import setup_logging
 from pigeon.base_msg import BaseMessage
 
 
@@ -15,8 +15,8 @@ logger = setup_logging("publisher")
 host = os.environ.get("ARTEMIS_HOST", "127.0.0.1")
 port = int(os.environ.get("ARTEMIS_PORT", 61616))
 
-connection = Pigeon("Publisher", host=host, port=port, logger=logger)
-connection.register_topic("test", TestMsg, "1.0")
+connection = Pigeon("Publisher", host=host, port=port, logger=logger, load_topics=False)
+connection.register_topic("test", TestMsg)
 connection.connect(username="admin", password="password")
 
 while True:

--- a/examples/subscriber.py
+++ b/examples/subscriber.py
@@ -1,7 +1,7 @@
 import os
 
 from pigeon.client import Pigeon
-from pigeon.logging import setup_logging
+from pigeon.utils import setup_logging
 from pigeon.base_msg import BaseMessage
 
 logger = setup_logging("subscriber")
@@ -18,8 +18,8 @@ def handle_test_message(topic, message):
     logger.info(f"Received {topic} message: {message}")
 
 
-connection = Pigeon("Subscriber", host=host, port=port, logger=logger)
-connection.register_topic("test", TestMsg, "1.0")
+connection = Pigeon("Subscriber", host=host, port=port, logger=logger, load_topics=False)
+connection.register_topic("test", TestMsg)
 connection.connect(username="admin", password="password")
 connection.subscribe("test", handle_test_message)
 

--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -9,7 +9,7 @@ from importlib.metadata import entry_points
 from pydantic import ValidationError
 
 from . import exceptions
-from .utils import call_with_correct_args
+from .utils import get_message_hash, call_with_correct_args
 
 
 def get_str_time_ms():
@@ -26,10 +26,9 @@ class Pigeon:
     in two ways. One is to use the register_topic(), or register_topics()
     methods. The other is to have message definitions in a Python package
     with an entry point defined in the pigeon.msgs group. This entry point
-    should provide a tuple containing a mapping of topics to Pydantic models,
-    and the message version. Topics defined in this manner will be
-    automatically discovered and loaded at runtime, unless this mechanism is
-    manually disabled.
+    should provide a tuple containing a mapping of topics to Pydantic models.
+    Topics defined in this manner will be automatically discovered and loaded at
+    runtime, unless this mechanism is manually disabled.
     """
 
     def __init__(
@@ -53,7 +52,7 @@ class Pigeon:
         self._service = service
         self._connection = stomp.Connection12([(host, port)], heartbeats=(10000, 10000))
         self._topics = {}
-        self._msg_versions = {}
+        self._hashes = {}
         if load_topics:
             self._load_topics()
         self._callbacks: Dict[str, Callable] = {}
@@ -72,26 +71,24 @@ class Pigeon:
         for entrypoint in entry_points(group="pigeon.msgs"):
             self.register_topics(*entrypoint.load())
 
-    def register_topic(self, topic: str, msg_class: Callable, version: str):
+    def register_topic(self, topic: str, msg_class: Callable):
         """Register message definition for a given topic.
 
         Args:
             topic: The topic that this message definition applies to.
             msg_class: The Pydantic model definition of the message.
-            version: The version of the message.
         """
         self._topics[topic] = msg_class
-        self._msg_versions[topic] = version
+        self._hashes[topic] = get_message_hash(msg_class)
 
-    def register_topics(self, topics: Dict[str, Callable], version: str):
+    def register_topics(self, topics: Dict[str, Callable]):
         """Register a number of message definitions for multiple topics.
 
         Args:
             topics: A mapping of topics to Pydantic model message definitions.
-            version: The version of these messages.
         """
         for topic in topics.items():
-            self.register_topic(*topic, version)
+            self.register_topic(*topic)
 
     def connect(
         self,
@@ -143,26 +140,26 @@ class Pigeon:
         serialized_data = self._topics[topic](**data).serialize()
         headers = dict(
             service=self._service,
-            version=self._msg_versions[topic],
+            hash=self._hashes[topic],
             sent_at=get_str_time_ms(),
         )
         self._connection.send(destination=topic, body=serialized_data, headers=headers)
         self._logger.debug(f"Sent data to {topic}: {serialized_data}")
 
     def _ensure_topic_exists(self, topic: str):
-        if topic not in self._topics or topic not in self._msg_versions:
+        if topic not in self._topics or topic not in self._hashes:
             raise exceptions.NoSuchTopicException(f"Topic {topic} not defined.")
 
     def _handle_message(self, message_frame: Frame):
         topic = message_frame.headers["subscription"]
-        if topic not in self._topics or topic not in self._msg_versions:
+        if topic not in self._topics or topic not in self._hashes:
             self._logger.warning(
                 f"Received a message on an unregistered topic: {topic}"
             )
             return
-        if message_frame.headers.get("version") != self._msg_versions.get(topic):
+        if message_frame.headers.get("hash") != self._hashes.get(topic):
             self._logger.warning(
-                f"Received a message on topic '{topic}' with an incorrect version {message_frame.headers.get('version')}. Version should be {self._msg_versions.get(topic)}"
+                f"Received a message on topic '{topic}' with an incorrect hash: {message_frame.headers.get('hash')}. Expected: {self._hashes.get(topic)}"
             )
             return
         try:

--- a/pigeon/utils.py
+++ b/pigeon/utils.py
@@ -1,6 +1,8 @@
 import logging
 import inspect
 from copy import copy
+import hashlib
+from typing import Callable
 
 from .exceptions import SignatureException
 
@@ -15,6 +17,12 @@ def setup_logging(logger_name: str, log_level: int = logging.INFO):
     logger.addHandler(handler)
     logger.setLevel(log_level)
     return logger
+
+
+def get_message_hash(msg_cls: Callable):
+    hash = hashlib.sha1()
+    hash.update(inspect.getsource(msg_cls).encode("utf8"))
+    return hash.hexdigest()
 
 
 def call_with_correct_args(func, *args, **kwargs):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,9 +6,6 @@ from pigeon.exceptions import NoSuchTopicException
 from pigeon import BaseMessage
 
 
-__version__ = "v1.2.3"
-
-
 class MockMessage(BaseMessage):
     field1: str
 
@@ -18,9 +15,10 @@ def pigeon_client():
     with patch("pigeon.utils.setup_logging") as mock_logging:
         topics = {"topic1": MockMessage}
         client = Pigeon(
-            "test", host="localhost", port=61613, logger=mock_logging.Logger()
+            "test", host="localhost", port=61613, logger=mock_logging.Logger(),
+            load_topics=False,
         )
-        client.register_topics(topics, __version__)
+        client.register_topics(topics)
         yield client
 
 
@@ -83,7 +81,7 @@ def test_connect_failure(pigeon_client, username, password):
 )
 def test_send(pigeon_client, topic, data, expected_serialized_data):
 
-    expected_headers = {"service": "test", "version": __version__, "sent_at": "1"}
+    expected_headers = {"service": "test", "hash": pigeon_client._hashes["topic1"], "sent_at": "1"}
     # Arrange
     with patch("pigeon.client.time.time_ns", lambda: 1e6):
         pigeon_client._topics[topic] = MockMessage

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,10 @@
+from pigeon.utils import get_message_hash
+
+
+def test_get_message_hash():
+    class TestMsg:
+        attr_one: int
+        attr_two: str
+        attr_three: float
+
+    assert get_message_hash(TestMsg) == "e6b05f8920682eca0ba8b415c9fa7a7f248ddfce"


### PR DESCRIPTION
This PR implements a message hashing system where message definitions are hashed, and this is used instead of a message version. This has the advantage that versions do not need to be manually set, and each topic essentially gets its own version automatically.

See #12