### PR TITLE
Spawn Threads for Callbacks

### DIFF
--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -231,7 +231,7 @@ class Pigeon:
         else:
             Thread(
                 target=self._run_callback,
-                args=(message_data, topic, message_frame.headers),
+                args=(callback, message_data, topic, message_frame.headers),
             ).start()
 
     def _run_callback(self, callback, message_data, topic, headers):


### PR DESCRIPTION
As callbacks are normally run in the STOMP communication thread, long-running callbacks can lead to heartbeat timeouts, ultimately resulting in program crashes. To avoid this issue, a new option has been added to the client, `spawn_threads`, which causes a new thread to be run for every message received.